### PR TITLE
86eqdy26f #fix about us tab text in mobile view

### DIFF
--- a/packages/core-library/components/Tabs/Tabs.tsx
+++ b/packages/core-library/components/Tabs/Tabs.tsx
@@ -100,12 +100,13 @@ export const Tabs: React.FC<Props> = ({
                     width: '100%',
                     textAlign: 'center',
                     mb: 2,
+                    py: 5,
                   }}
                 >
                   {tab.title}
                 </TabButton>
                 <Collapse in={selected === tab.id} timeout='auto' unmountOnExit>
-                  <Box mt={2}>{tab.content}</Box>
+                  <Box>{tab.content}</Box>
                 </Collapse>
               </Box>
             ))}

--- a/packages/core-library/components/Tabs/Tabs.tsx
+++ b/packages/core-library/components/Tabs/Tabs.tsx
@@ -1,8 +1,8 @@
-import { Box, Grid } from "@mui/material";
-import { ReactElement, ReactNode, useEffect, useRef, useState } from "react";
-import { TabButton } from "../Button/TabButton";
-import { useResolution } from "../../hooks";
-import { TabsItem } from "../../core/utils/contants/tabs-item";
+import { Box, Collapse, Grid } from '@mui/material';
+import { ReactElement, ReactNode, useEffect, useRef, useState } from 'react';
+import { TabButton } from '../Button/TabButton';
+import { useResolution } from '../../hooks';
+import { TabsItem } from '../../core/utils/contants/tabs-item';
 
 interface CustomStyleProps {
   background?: string;
@@ -13,7 +13,7 @@ interface CustomStyleProps {
 interface Props {
   id?: string;
   tabsItem: TabsItem[];
-  justifyContent?: "flex-start" | "center" | "flex-end";
+  justifyContent?: 'flex-start' | 'center' | 'flex-end';
   width?: string | number;
   selectedTabIndex?: (value: number) => void;
   customStyle?: CustomStyleProps;
@@ -25,17 +25,19 @@ export const Tabs: React.FC<Props> = ({
   justifyContent,
   width,
   selectedTabIndex,
-  customStyle
+  customStyle,
 }) => {
   const { isMobile } = useResolution();
-  const [selected, setSelected] = useState(1);
+  const [selected, setSelected] = useState<number | null>(1);
   const tabs = tabsHeader(tabsItem);
   const selectedTab = tabs.find((tab) => tab.id === selected);
   const tabsRef = useRef<HTMLElement[]>([]);
 
   useEffect(() => {
-    selectedTabIndex && selectedTabIndex(selected);
-  }, [selectedTabIndex]);
+    if (selected !== null && selectedTabIndex) {
+      selectedTabIndex(selected);
+    }
+  }, [selected, selectedTabIndex]);
 
   return (
     <Grid container spacing={12}>
@@ -52,15 +54,21 @@ export const Tabs: React.FC<Props> = ({
                 active={selected === tab.id}
                 href={`#tab-section-${index + 1}`}
                 sx={{
-                  "&:hover": {
-                    background: selected === tab.id ? customStyle?.background : "default",
+                  '&:hover': {
+                    background:
+                      selected === tab.id ? customStyle?.background : 'default',
                   },
-                  width: "auto",
-                  background: selected === tab.id ? customStyle?.background : "default",
-                  border: "none",
-                  color: selected === tab.id ? customStyle?.selectedColor : customStyle?.defaultColor || 'default',
-                  borderBottom: selected === tab.id ? customStyle?.borderBottom : 'default',
-                  marginLeft: tab.id !== 1 ? "-1px" : "unset",
+                  width: 'auto',
+                  background:
+                    selected === tab.id ? customStyle?.background : 'default',
+                  border: 'none',
+                  color:
+                    selected === tab.id
+                      ? customStyle?.selectedColor
+                      : customStyle?.defaultColor || 'default',
+                  borderBottom:
+                    selected === tab.id ? customStyle?.borderBottom : 'default',
+                  marginLeft: tab.id !== 1 ? '-1px' : 'unset',
                 }}
                 onClick={(e) => handleSelected(e, tab.id)}
                 onKeyDown={(e) => handleKeyDown(e, tab.id)}
@@ -72,27 +80,44 @@ export const Tabs: React.FC<Props> = ({
           ))}
         </Grid>
       )}
-      {isMobile
-        ? tabs?.map((tab, index) => (
-            <Grid item xs={12} key={tab.id}>
-              {tab.content}
-              {tabs.length - 1 !== index && (
-                <Box
-                  mt={12}
+      {isMobile ? (
+        <Grid item xs={12}>
+          <Box>
+            {tabs.map((tab) => (
+              <Box key={tab.id} mb={4}>
+                <TabButton
+                  active={selected === tab.id}
+                  onClick={() =>
+                    setSelected((prev) => (prev === tab.id ? null : tab.id))
+                  }
                   sx={{
-                    backgroundColor: "primary.main",
-                    height: "4px",
-                    width: "100%",
+                    background:
+                      selected === tab.id ? customStyle?.background : 'default',
+                    color:
+                      selected === tab.id
+                        ? customStyle?.selectedColor
+                        : customStyle?.defaultColor || 'default',
+                    width: '100%',
+                    textAlign: 'center',
+                    mb: 2,
                   }}
-                />
-              )}
-            </Grid>
-          ))
-        : selectedTab && (
-            <Grid item xs={12}>
-              {selectedTab.content}
-            </Grid>
-          )}
+                >
+                  {tab.title}
+                </TabButton>
+                <Collapse in={selected === tab.id} timeout='auto' unmountOnExit>
+                  <Box mt={2}>{tab.content}</Box>
+                </Collapse>
+              </Box>
+            ))}
+          </Box>
+        </Grid>
+      ) : (
+        selectedTab && (
+          <Grid item xs={12}>
+            {selectedTab.content}
+          </Grid>
+        )
+      )}
     </Grid>
   );
 
@@ -113,12 +138,12 @@ export const Tabs: React.FC<Props> = ({
     const tabsLength = tabs.length;
 
     switch (e.code) {
-      case "ArrowLeft":
+      case 'ArrowLeft':
         if (id > 1) {
           handleSelected(e, id - 1);
         }
         break;
-      case "ArrowRight":
+      case 'ArrowRight':
         if (id < tabsLength) {
           handleSelected(e, id + 1);
         }
@@ -134,6 +159,6 @@ const tabsHeader = (
 ): { id: number; title: string; content?: ReactNode | ReactElement }[] =>
   tabs.map((tab, index) => ({
     id: index + 1,
-    title: tab.title ?? "",
+    title: tab.title ?? '',
     content: tab.content,
   }));


### PR DESCRIPTION
Before
![before_about_us_tab](https://github.com/user-attachments/assets/9e51a5d2-cccd-4f0a-a033-7cc71860bac2)
After
![after_about_us_tab](https://github.com/user-attachments/assets/6bf3354c-bd54-4b6b-bc23-cbbe357fe91d)
![after_about_us_tab1](https://github.com/user-attachments/assets/1206a9c7-81fd-4139-aaf9-1dc2e719ba3b)
